### PR TITLE
Adding Python3.10 Support For Automated Tests In Github CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Python3.10 was released not too long ago (10/4/2021) so just adding this specific version to the python workflow.