### PR TITLE
chore: can specify config section via cli arg

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -99,7 +99,7 @@ def parse():
         metavar=''
     )
 
-    return parser.parse_args()
+    return parser.parse_known_args()[0]
 
 
 config = configparser.ConfigParser()


### PR DESCRIPTION
Makes it possible to specify a specific section of `duo.conf` to use when running the demo `app.py`, while still defaulting to `duo`. So for people who do not want to specify a config section manually, behavior does not change.

Made this change based on my own experience always editing different sections in my `duo.conf` file to be named `duo` whenever I wanted to be using that section.