### PR TITLE
Add Support For Passing Nonce and Configurable JWT Expiry

### DIFF
--- a/duo_universal/client.py
+++ b/duo_universal/client.py
@@ -12,7 +12,7 @@ from duo_universal.version import __version__
 CLIENT_ID_LENGTH = 20
 CLIENT_SECRET_LENGTH = 40
 JTI_LENGTH = 36
-MINIMUM_STATE_LENGTH = 22
+MINIMUM_STATE_LENGTH = 16
 MAXIMUM_STATE_LENGTH = 1024
 STATE_LENGTH = 36
 SUCCESS_STATUS_CODE = 200
@@ -37,6 +37,8 @@ ERR_NONCE_LEN = ('Nonce must be at least {MIN} characters long and no longer tha
     MIN=MINIMUM_STATE_LENGTH,
     MAX=MAXIMUM_STATE_LENGTH
 )
+ERR_EXP_SECONDS_TOO_LONG = 'Client may not be configured for a JWT expiry longer than five minutes.'
+ERR_EXP_SECONDS_TOO_SHORT = 'Invalid JWT expiry duration.'
 
 API_HOST_URI_FORMAT = "https://{}"
 OAUTH_V1_HEALTH_CHECK_ENDPOINT = "https://{}/oauth/v1/health_check"
@@ -52,6 +54,9 @@ class DuoException(Exception):
 
 
 class Client:
+    @property
+    def _clamped_expiry_duration(self):
+        return max(min(FIVE_MINUTES_IN_SECONDS, self._exp_seconds), 1)
 
     def _generate_rand_alphanumeric(self, length):
         """
@@ -75,7 +80,7 @@ class Client:
         return ''.join(generator.choice(characters) for i in range(length))
 
     def _validate_init_config(self, client_id, client_secret,
-                              api_host, redirect_uri):
+                              api_host, redirect_uri, exp_seconds):
         """
         Verifies __init__ parameters
 
@@ -85,6 +90,7 @@ class Client:
         client_secret   -- Client secret for the application in Duo
         host            -- Duo api host
         redirect_uri    -- Uri to redirect to after a successful auth
+        exp_seconds     -- The JWT expiry window
 
         Raises:
 
@@ -98,6 +104,10 @@ class Client:
             raise DuoException(ERR_API_HOST)
         if not redirect_uri:
             raise DuoException(ERR_REDIRECT_URI)
+        if exp_seconds > FIVE_MINUTES_IN_SECONDS:
+            raise DuoException(ERR_EXP_SECONDS_TOO_LONG)
+        elif exp_seconds < 0:
+            raise DuoException(ERR_EXP_SECONDS_TOO_SHORT)
 
     def _validate_create_auth_url_inputs(self, username, state, nonce=None):
         if nonce and (MINIMUM_STATE_LENGTH >= len(nonce) or len(nonce) >= MAXIMUM_STATE_LENGTH):
@@ -112,7 +122,7 @@ class Client:
             'iss': self._client_id,
             'sub': self._client_id,
             'aud': endpoint,
-            'exp': time.time() + self._exp_seconds,
+            'exp': time.time() + self._clamped_expiry_duration,
             'jti': self._generate_rand_alphanumeric(JTI_LENGTH)
         }
 
@@ -133,13 +143,14 @@ class Client:
         duo_certs                -- (Optional) Provide custom CA certs
         use_duo_code_attribute   -- (Optional: default true) Flag to use `duo_code` instead of `code` for returned authorization parameter
         http_proxy               -- (Optional) HTTP proxy to tunnel requests through
-        exp_seconds              -- (Optional) The number of seconds used for JWT expiry
+        exp_seconds              -- (Optional) The number of seconds used for JWT expiry. Must be be at most 5 minutes.
         """
 
         self._validate_init_config(client_id,
                                    client_secret,
                                    host,
-                                   redirect_uri)
+                                   redirect_uri,
+                                   exp_seconds)
 
         self._client_id = client_id
         self._client_secret = client_secret
@@ -213,10 +224,10 @@ class Client:
         Arguments:
 
         username        -- username trying to authenticate with Duo
-        state           -- Randomly generated character string of at least 22
-                           chars returned to the integration by Duo after 2FA
+        state           -- Randomly generated character string of at least 16
+                           and at most 1024 characters returned to the integration by Duo after 2FA
         nonce           -- Randomly generated character string of at least 16
-                           characters used as the nonce for the underlying OIDC flow
+                           and at most 1024 characters used as the nonce for the underlying OIDC flow
 
         Returns:
 
@@ -233,7 +244,7 @@ class Client:
             'client_id': self._client_id,
             'iss': self._client_id,
             'aud': API_HOST_URI_FORMAT.format(self._api_host),
-            'exp': time.time() + self._exp_seconds,
+            'exp': time.time() + self._clamped_expiry_duration,
             'state': state,
             'response_type': 'code',
             'duo_uname': username,

--- a/tests/test_setup_client.py
+++ b/tests/test_setup_client.py
@@ -98,10 +98,10 @@ class TestCheckConf(unittest.TestCase):
         Test to validate that a user can't set an expiry longer than 5 minutes.
         """
         with self.assertRaises(client.DuoException) as e:
-            self.client._validate_init_config(CLIENT_ID, CLIENT_SECRET, HOST, REDIRECT_URI, 2*EXP_SECONDS)
+            self.client._validate_init_config(CLIENT_ID, CLIENT_SECRET, HOST, REDIRECT_URI, 2 * EXP_SECONDS)
             self.assertEqual(e, client.ERR_EXP_SECONDS_TOO_LONG)
         # Even if the end user forcefully sets the expiry, ensure the clamped value is in spec.
-        self.client._exp_seconds = 2*EXP_SECONDS
+        self.client._exp_seconds = 2 * EXP_SECONDS
         self.assertEqual(self.client._clamped_expiry_duration, client.FIVE_MINUTES_IN_SECONDS)
 
     def test_exp_seconds_too_short(self):

--- a/tests/test_validate_create_auth_url_inputs.py
+++ b/tests/test_validate_create_auth_url_inputs.py
@@ -44,6 +44,22 @@ class TestCreateAuthUrlInputs(unittest.TestCase):
             self.client._validate_create_auth_url_inputs(USERNAME, LONG_LENGTH)
             self.assertEqual(e, client.ERR_STATE)
 
+    def test_short_nonce(self):
+        """
+        Test _validate_create_auth_url_inputs
+        throws a DuoException if the nonce is set and is too short
+        """
+        with self.assertRaises(client.DuoException) as e:
+            self.client._validate_create_auth_url_inputs(USERNAME, STATE, nonce=SHORT_STATE)
+
+    def test_long_nonce(self):
+        """
+        Test _validate_create_auth_url_inputs
+        throws a DuoException if the nonce is set and is too long
+        """
+        with self.assertRaises(client.DuoException) as e:
+            self.client._validate_create_auth_url_inputs(USERNAME, STATE, nonce=LONG_LENGTH)
+
     def test_no_username(self):
         """
         Test _validate_create_auth_url_inputs
@@ -59,6 +75,13 @@ class TestCreateAuthUrlInputs(unittest.TestCase):
         does not throw an error for valid inputs
         """
         self.client._validate_create_auth_url_inputs(USERNAME, STATE)
+
+    def test_success_with_nonce(self):
+        """
+        Test _validate_create_auth_url_inputs
+        does not throw an error for valid inputs
+        """
+        self.client._validate_create_auth_url_inputs(USERNAME, STATE, nonce=STATE)
 
 
 if __name__ == '__main__':

--- a/tests/test_validate_create_auth_url_inputs.py
+++ b/tests/test_validate_create_auth_url_inputs.py
@@ -51,6 +51,7 @@ class TestCreateAuthUrlInputs(unittest.TestCase):
         """
         with self.assertRaises(client.DuoException) as e:
             self.client._validate_create_auth_url_inputs(USERNAME, STATE, nonce=SHORT_STATE)
+            self.assertEqual(e, client.ERR_NONCE_LEN)
 
     def test_long_nonce(self):
         """
@@ -59,6 +60,7 @@ class TestCreateAuthUrlInputs(unittest.TestCase):
         """
         with self.assertRaises(client.DuoException) as e:
             self.client._validate_create_auth_url_inputs(USERNAME, STATE, nonce=LONG_LENGTH)
+            self.assertEqual(e, client.ERR_NONCE_LEN)
 
     def test_no_username(self):
         """


### PR DESCRIPTION
## Description
* Added support to the Python client to allow the nonce to be set in the auth URL
* Added a client parameter to allow JWT expiry to be configured.
* Updated some tests to check nonce validation.

## Motivation and Context
I am working on integrating the Duo Universal prompt into an existing Python application that already does OIDC auth flows, and utilizing the OIDC nonce and potentially setting a shorter expiry window is being considered. These are supported in the Duo OIDC doc, but not exposed in the Python client library, so this would add that.

## How Has This Been Tested?
* I've added a couple of unit tests.

## Types of Changes
- [?] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
