### PR TITLE
Pin cyclonedx-bom version to fix breaking change in release process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
         pip install setuptools wheel twine
     - name: Generate SBOM
       run: |
-        pip install cyclonedx-bom
+        pip install cyclonedx-bom==3.11.7
         ./scripts/make-sbom.sh
     - name: Build and publish
       env:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Cyclonedx-py 4.0.0 contains breaking changes. This pins it to a working version

## Motivation and Context
Using 4.0.0 gives this error during the release action
```
usage: cyclonedx-py [-h] [--version] <command> ...
cyclonedx-py: error: argument <command>: invalid choice: 'json' (choose from 'environment', 'requirements', 'pipenv', 'poetry')
```

## How Has This Been Tested?
Tested locally; downgrading to this version resolved the error.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
