### PR TITLE
Remove pyOpenSSL dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-cryptography>=3.2
 PyJWT>=2.0
 requests>=2.22.0
 wheel>=0.35.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 cryptography>=3.2
 PyJWT>=2.0
-pyOpenSSL>=19.0.0
 requests>=2.22.0
 wheel>=0.35.1


### PR DESCRIPTION
## Description
The pyOpenSSL module in `duo_universal_python` does not appear to be referenced.

## Motivation and Context
This change seeks to remove an unused module to reduce dependencies / attack surface.

## How Has This Been Tested?
Skimmed the code looking for why it's needed, found nothing.
Ran the test suite, it continued to pass.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] None of the above?