### PR TITLE
feat(client): add optional dest_app_name to auth request JWT

### DIFF
--- a/duo_universal/client.py
+++ b/duo_universal/client.py
@@ -218,7 +218,7 @@ class Client:
 
         return res
 
-    def create_auth_url(self, username, state, nonce=None):
+    def create_auth_url(self, username, state, nonce=None, dest_app_name=None):
         """Generate uri to Duo's prompt
 
         Arguments:
@@ -228,6 +228,7 @@ class Client:
                            and at most 1024 characters returned to the integration by Duo after 2FA
         nonce           -- Randomly generated character string of at least 16
                            and at most 1024 characters used as the nonce for the underlying OIDC flow
+        dest_app_name   -- Optional user-facing application name shown by Duo in various UI areas.
 
         Returns:
 
@@ -237,7 +238,6 @@ class Client:
         self._validate_create_auth_url_inputs(username, state, nonce=nonce)
 
         authorize_endpoint = OAUTH_V1_AUTHORIZE_ENDPOINT.format(self._api_host)
-
         jwt_args = {
             'scope': 'openid',
             'redirect_uri': self._redirect_uri,
@@ -250,6 +250,8 @@ class Client:
             'duo_uname': username,
             'use_duo_code_attribute': self._use_duo_code_attribute,
         }
+        if dest_app_name:
+            jwt_args['dest_app_name'] = dest_app_name
 
         request_jwt = jwt.encode(jwt_args,
                                  self._client_secret,

--- a/tests/test_create_auth.py
+++ b/tests/test_create_auth.py
@@ -10,6 +10,7 @@ HOST = "api-XXXXXXX.test.duosecurity.com"
 REDIRECT_URI = "https://www.example.com"
 USERNAME = "user1"
 STATE = "deadbeefdeadbeefdeadbeefdeadbeefdead"
+DEST_APP_NAME = "Example App"
 
 NONE = None
 
@@ -60,7 +61,34 @@ class TestCreateAuthUrl(unittest.TestCase):
 
         self._assert_client_creates_expected_uri(duo_client, expected_jwt_args)
 
-    def _assert_client_creates_expected_uri(self, duo_client, expected_jwt_args):
+    @patch('time.time', MagicMock(return_value=2))
+    def test_dest_app_name_on_create_auth_url(self):
+        """
+        Test create_auth_url includes dest_app_name in JWT payload
+        """
+        duo_client = client.Client(CLIENT_ID, CLIENT_SECRET, HOST, REDIRECT_URI)
+
+        expected_jwt_args = {
+            'scope': 'openid',
+            'redirect_uri': REDIRECT_URI,
+            'client_id': CLIENT_ID,
+            'iss': CLIENT_ID,
+            'aud': client.API_HOST_URI_FORMAT.format(HOST),
+            'exp': 302,
+            'state': STATE,
+            'response_type': 'code',
+            'duo_uname': USERNAME,
+            'use_duo_code_attribute': True,
+            'dest_app_name': DEST_APP_NAME,
+        }
+
+        self._assert_client_creates_expected_uri(
+            duo_client,
+            expected_jwt_args,
+            options={'dest_app_name': DEST_APP_NAME},
+        )
+
+    def _assert_client_creates_expected_uri(self, duo_client, expected_jwt_args, options=None):
         authorize_endpoint = \
             client.OAUTH_V1_AUTHORIZE_ENDPOINT.format(HOST)
 
@@ -74,7 +102,11 @@ class TestCreateAuthUrl(unittest.TestCase):
 
         expected_authorization_uri = "{}?{}".format(authorize_endpoint,
                                                     encoded_all_args)
-        actual_authorization_uri = duo_client.create_auth_url(USERNAME, STATE)
+        actual_authorization_uri = duo_client.create_auth_url(
+            USERNAME,
+            STATE,
+            **(options or {}),
+        )
 
         self.assertEqual(expected_authorization_uri, actual_authorization_uri)
 


### PR DESCRIPTION
- Extend create_auth_url with optional dest_app_name for Duo OIDC request.payload.dest_app_name
- Include dest_app_name in the signed request JWT only when provided
- Add unit test coverage for the authorization URI JWT payload

## Description

This change extends `Client.create_auth_url` with an optional `dest_app_name`
parameter. When provided and truthy, `dest_app_name` is included in the signed
authorization `request` JWT payload as `dest_app_name`, matching Duo’s OIDC
Auth API field for a user-facing destination application name.

## Motivation and Context

Duo documents `dest_app_name` as an optional field in the authorization request
JWT payload. Our Duo Admin expressed that it was a nice touch when they were looking
at logs that included it.

Reference: https://duo.com/docs/oauthapi#authorization-request

## How Has This Been Tested?

Added/updated unit coverage in tests/test_create_auth.py to assert the
generated authorization URI’s `request` JWT includes `dest_app_name` when
passed to `create_auth_url`.

Also tested it on one of dev apps and our Duo Admin confirmed that the dest_app_name
was showing.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
