### PR TITLE
Add CA bundle version and pinning status to user agent string

### DIFF
--- a/duo_universal/client.py
+++ b/duo_universal/client.py
@@ -321,11 +321,11 @@ class Client:
             user_agent = ("duo_universal_python/{version} "
                           "python/{python_version} {os_name} "
                           "ca_bundle/{ca_bundle_version} "
-                          "ca_pinning: {ca_pinning_status}").format(version=__version__,
-                                                                    python_version=platform.python_version(),
-                                                                    os_name=platform.platform(),
-                                                                    ca_bundle_version=CA_BUNDLE_VERSION,
-                                                                    ca_pinning_status=ca_pinning_status)
+                          "(ca_pinning={ca_pinning_status})").format(version=__version__,
+                                                                     python_version=platform.python_version(),
+                                                                     os_name=platform.platform(),
+                                                                     ca_bundle_version=CA_BUNDLE_VERSION,
+                                                                     ca_pinning_status=ca_pinning_status)
             response = requests.post(token_endpoint,
                                      params=all_args,
                                      headers={"user-agent":

--- a/duo_universal/client.py
+++ b/duo_universal/client.py
@@ -45,6 +45,7 @@ OAUTH_V1_HEALTH_CHECK_ENDPOINT = "https://{}/oauth/v1/health_check"
 OAUTH_V1_AUTHORIZE_ENDPOINT = "https://{}/oauth/v1/authorize"
 OAUTH_V1_TOKEN_ENDPOINT = "https://{}/oauth/v1/token"
 DEFAULT_CA_CERT_PATH = os.path.join(os.path.dirname(__file__), 'ca_certs.pem')
+CA_BUNDLE_VERSION = "1.0"
 
 CLIENT_ASSERT_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 
@@ -316,10 +317,15 @@ class Client:
                                            algorithm='HS512')
         }
         try:
+            ca_pinning_status = "disabled" if self._disable_ca_pinning else "enabled"
             user_agent = ("duo_universal_python/{version} "
-                          "python/{python_version} {os_name}").format(version=__version__,
-                                                                      python_version=platform.python_version(),
-                                                                      os_name=platform.platform())
+                          "python/{python_version} {os_name} "
+                          "ca_bundle/{ca_bundle_version} "
+                          "ca_pinning: {ca_pinning_status}").format(version=__version__,
+                                                                    python_version=platform.python_version(),
+                                                                    os_name=platform.platform(),
+                                                                    ca_bundle_version=CA_BUNDLE_VERSION,
+                                                                    ca_pinning_status=ca_pinning_status)
             response = requests.post(token_endpoint,
                                      params=all_args,
                                      headers={"user-agent":

--- a/tests/test_setup_client.py
+++ b/tests/test_setup_client.py
@@ -281,7 +281,7 @@ class TestUserAgent(unittest.TestCase):
         except client.DuoException:
             pass
         _, kwargs = requests_mock.call_args
-        self.assertIn('ca_pinning: enabled', kwargs['headers']['user-agent'])
+        self.assertIn('(ca_pinning=enabled)', kwargs['headers']['user-agent'])
 
     @patch('requests.post')
     def test_user_agent_ca_pinning_disabled(self, requests_mock):
@@ -296,7 +296,7 @@ class TestUserAgent(unittest.TestCase):
         except client.DuoException:
             pass
         _, kwargs = requests_mock.call_args
-        self.assertIn('ca_pinning: disabled', kwargs['headers']['user-agent'])
+        self.assertIn('(ca_pinning=disabled)', kwargs['headers']['user-agent'])
 
 
 if __name__ == '__main__':

--- a/tests/test_setup_client.py
+++ b/tests/test_setup_client.py
@@ -253,5 +253,51 @@ class TestDisableCaPinningRequests(unittest.TestCase):
         self.assertEqual(kwargs['verify'], client.DEFAULT_CA_CERT_PATH)
 
 
+class TestUserAgent(unittest.TestCase):
+
+    @patch('requests.post')
+    def test_user_agent_includes_ca_bundle_version(self, requests_mock):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'id_token': 'fake'}
+        requests_mock.return_value = mock_response
+        c = client.Client(CLIENT_ID, CLIENT_SECRET, HOST, REDIRECT_URI)
+        try:
+            c.exchange_authorization_code_for_2fa_result('code', 'user')
+        except client.DuoException:
+            pass
+        _, kwargs = requests_mock.call_args
+        self.assertIn('ca_bundle/1.0', kwargs['headers']['user-agent'])
+
+    @patch('requests.post')
+    def test_user_agent_ca_pinning_enabled(self, requests_mock):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'id_token': 'fake'}
+        requests_mock.return_value = mock_response
+        c = client.Client(CLIENT_ID, CLIENT_SECRET, HOST, REDIRECT_URI)
+        try:
+            c.exchange_authorization_code_for_2fa_result('code', 'user')
+        except client.DuoException:
+            pass
+        _, kwargs = requests_mock.call_args
+        self.assertIn('ca_pinning: enabled', kwargs['headers']['user-agent'])
+
+    @patch('requests.post')
+    def test_user_agent_ca_pinning_disabled(self, requests_mock):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'id_token': 'fake'}
+        requests_mock.return_value = mock_response
+        c = client.Client(CLIENT_ID, CLIENT_SECRET, HOST, REDIRECT_URI,
+                          disable_ca_pinning=True)
+        try:
+            c.exchange_authorization_code_for_2fa_result('code', 'user')
+        except client.DuoException:
+            pass
+        _, kwargs = requests_mock.call_args
+        self.assertIn('ca_pinning: disabled', kwargs['headers']['user-agent'])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Added `CA_BUNDLE_VERSION = '1.0'` constant in `duo_universal/client.py`
- Modified `exchange_authorization_code_for_2fa_result` to append `ca_bundle/1.0` and `ca_pinning: enabled|disabled` to the user agent string based on the `disable_ca_pinning` runtime state

## How Has This Been Tested?
- `test_user_agent_includes_ca_bundle_version` — verifies `ca_bundle/1.0` is present in the user agent
- `test_user_agent_ca_pinning_enabled` — verifies `ca_pinning: enabled` when pinning is not disabled
- `test_user_agent_ca_pinning_disabled` — verifies `ca_pinning: disabled` when `disable_ca_pinning=True`

## Types of Changes
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)